### PR TITLE
Codex rules fix and additional codex entry updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Contributors:
     - structure base damage: 0.85 -> 0.65
 - Thief
     - Steal can now target transports, which will take it over AND kill the thief
-- Barge, Turle, Harpoon Ship, Warship
+- Barge, Turtle, Harpoon Ship, Warship
     - New mechanic: If the unit's action is to "wait", it gets an additional move-only turn
         - Turtle move-only movement range: 6  (rest of ships have same mvt for 1st and 2nd action)
     - Barge has a special action that's only activated if it's not carrying any units

--- a/gow_co_balance_mod/assets_src/config/gameplay/codex/codex_rules.yaml
+++ b/gow_co_balance_mod/assets_src/config/gameplay/codex/codex_rules.yaml
@@ -8,12 +8,12 @@ codex:
     image: ui/codex/icons/icon_modProjectGroove_rules.png
   pages:
   - pageType: page
-    layoutType: animation
+    layoutType: no_image # Animation type causes crashes. Update when workaround is discovered or issue is resolved.
     animation: ui/codex/content/projectgroove_overheal
     title: codex_rules_projectgroove_overheal_title
     text: codex_rules_projectgroove_overheal_text_1
   - pageType: page
-    layoutType: animation
+    layoutType: no_image # Animation type causes crashes. Update when workaround is discovered or issue is resolved.
     animation: ui/codex/content/projectgroove_overheal
     title: codex_rules_projectgroove_overheal_title
     text: codex_rules_projectgroove_overheal_text_2
@@ -25,12 +25,12 @@ codex:
     image: ui/codex/icons/icon_modProjectGroove_rules.png
   pages:
   - pageType: page
-    layoutType: animation
+    layoutType: no_image # Animation type causes crashes. Update when workaround is discovered or issue is resolved.
     animation: ui/codex/content/projectgroove_mana
     title: codex_rules_projectgroove_mana_title
     text: codex_rules_projectgroove_mana_text_1
   - pageType: page
-    layoutType: animation
+    layoutType: no_image # Animation type causes crashes. Update when workaround is discovered or issue is resolved.
     animation: ui/codex/content/projectgroove_mana
     title: codex_rules_projectgroove_mana_title
     text: codex_rules_projectgroove_mana_text_2
@@ -42,12 +42,12 @@ codex:
     image: ui/codex/icons/icon_modProjectGroove_rules.png
   pages:
   - pageType: page
-    layoutType: animation
+    layoutType: no_image # Animation type causes crashes. Update when workaround is discovered or issue is resolved.
     animation: ui/codex/content/projectgroove_rng
     title: codex_rules_projectgroove_rng_title
     text: codex_rules_projectgroove_rng_text_1
   - pageType: page
-    layoutType: animation
+    layoutType: no_image # Animation type causes crashes. Update when workaround is discovered or issue is resolved.
     animation: ui/codex/content/projectgroove_rng
     title: codex_rules_projectgroove_rng_title
     text: codex_rules_projectgroove_rng_text_2

--- a/gow_co_balance_mod/assets_src/config/strings/en-GB.yaml
+++ b/gow_co_balance_mod/assets_src/config/strings/en-GB.yaml
@@ -65,4 +65,16 @@ en-GB:
 
   # Turtle
   unit_description_turtle: "Powerful naval unit, built to conquer the water. Half movement after waiting. Critical hit when in deep sea."
+  
+  # CODEX / COMMANDERS
+  codex_groove_description_caesar: "Caesar's majestic presence inspires all adjacent units to dig deep and have a second go.\n\nGroove Charge Speed: Slow."
+  codex_groove_description_mercia: "Mercia raises her sword to the sky and heals all surrounding allied units by 50%, overhealing all units up to 105%\n\nGroove Charge Speed: Fast."
+  codex_groove_description_nuru: "Nuru beams down a friendly unit in the heat of battle. You can only summon units normally found as a squadron (e.g. Dogs) and can currently recruit. You pay double gold for the unit, but no Mana.\n\nGroove Charge Speed: Medium."
+  codex_groove_description_ryota: "Ryota dashes through rows of enemies, dealing 50% of the damage he would inflict at full health. The damage decreases by 3% per row. Ryota can dash through neutral structures.\n\nGroove Charge Speed: Fast."
+  codex_groove_description_sigrid: "Sigrid flies up to 2 tiles away, before draining all health from an enemy unit, and adds it to her own health. \n\nGroove Charge Speed: Medium."
+  codex_groove_description_twins: "The twins have access to two successive Grooves: Scorching Fire and Cooling Water. \nFirst, you use Scorching Fire, starting a fire on a single tile. For three turns, the flaming area grows in size, and after four turns, it disappears. Any unit caught in the flames will be instantly defeated. \nAfterwards, you may optionally also use Cooling Water, covering an area with healing magic. Each turn, the area decreases in size, and after four turns it disappears. Any units left in the area at the start of the twins' turn are healed for 20% of their full health. \n\nGroove Charge Speed: Medium."
+  codex_groove_description_vesper: "Vesper can warp to anywhere on the map and summon a small shroud around her in thick, magical smoke for one turn. Units within this area cannot be targeted or counter-attacked. \n\nGroove Charge Speed: Slow."
+  codex_groove_description_darkmercia: "Dark Mercia raises her sword to the sky and drains all surrounding enemy units by 25%, healing herself, and overhealing up to 200%. \n\nGroove Charge Speed: Medium."
+  codex_groove_description_mercival: "Mercival diplomatically claims any enemy building to join his side at full strength, and steals 100 gold from the enemy. Cannot be used on Strongholds. \n\nGroove Charge Speed: Fast."
+  codex_groove_description_elodie": "Requiem entrances an enemy unit, bringing it under Elodie's control. \n\nGroove charge speed: Medium."
 ...

--- a/gow_co_balance_mod/assets_src/config/strings/en-GB.yaml
+++ b/gow_co_balance_mod/assets_src/config/strings/en-GB.yaml
@@ -55,7 +55,14 @@ en-GB:
   codex_rules_projectgroove_rng_text_2: "Like before, final damage values are rounded from decimal values.\nExample:\n> 34 avg. results in 31.6 - 38.4, giving a range of 32 - 38."
 
   # CODEX / UNITS
+  # Thief
   unit_description_thief: "A vulnerable unit that can steal 300 gold from enemy buildings, 1000 from a Stronghold, or take over a transport!"
   codex_unit_thief_critical_text: "Thieves are able to instantly neutralise structures, and as such, excel at threatening dangerous areas of the battlefield alone. They are often at their most effective when diverting attention away from the frontlines, and when used effectively, they can turn the economic tide of battle. Additionally, thieves can take over enemy transports, working as a detterent to potential supply lines or the use of cheap blockades."
   
+  # Barge
+  unit_description_travelboat: "Boats able to transport all ground units across water. Able to move twice when empty."
+  codex_unit_travelboat_critical_text: "The Barge is primarily used to transport ground units across sea tiles. Care must be taken, as Barges are vulnerable, and loaded units will be lost if the boat is defeated. However, with its extremely mobile speed when unoccupied, they make effective blockades. A Barge can also move towards a beach before units load onto it, allowing for rapid transportation with only a single vehicle."
+
+  # Turtle
+  unit_description_turtle: "Powerful naval unit, built to conquer the water. Half movement after waiting. Critical hit when in deep sea."
 ...


### PR DESCRIPTION
Added custom strings for the codex entries of several units and commanders to be consistent with the changes made in the mod.

I also added a temporary fix for the crashing issue, disabling animations. All resources are maintained but for now will go unused. No crash issue has been found using the `no_image` page type. The `image` type is currently not usable either.

Also, fixed a typo in the README file.